### PR TITLE
Add generic type to SetTheoryNodeSupplier.

### DIFF
--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/supplier/SetTheoryNodeSupplier.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/supplier/SetTheoryNodeSupplier.java
@@ -14,18 +14,19 @@ import com.mmm.his.cer.utility.farser.lexer.set.SetTheoryToken;
  * Set theory node supplier. Contains the knowledge to create terminal and non-terminal nodes for
  * Set theory evaluation.
  *
+ * @param <T> The type that is returned from the LookupContext implementation
  * @author Mike Funaro
  */
-public class SetTheoryNodeSupplier implements NodeSupplier<SetTheoryToken, LookupContext<String>> {
+public class SetTheoryNodeSupplier<T> implements NodeSupplier<SetTheoryToken, LookupContext<T>> {
 
 
   @Override
-  public Expression<LookupContext<String>, ?> createNode(SetTheoryToken token) {
+  public Expression<LookupContext<T>, ?> createNode(SetTheoryToken token) {
     return new DataLookupNode<>(token.value);
   }
 
   @Override
-  public NonTerminal<LookupContext<String>, ?> createNonTerminalNode(SetTheoryToken token) {
+  public NonTerminal<LookupContext<T>, ?> createNonTerminalNode(SetTheoryToken token) {
     switch (token.type) {
       case DIFFERENCE:
         return new DifferenceOperator<>();

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/LookupContext.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/LookupContext.java
@@ -12,7 +12,7 @@ public interface LookupContext<T> {
   /**
    * Fetch data from a source.
    *
-   * @param key the key of the daya.
+   * @param key the key of the data.
    * @return a list of data.
    */
   List<T> lookupData(String key);

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_set/SetAstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_set/SetAstTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTree;
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter;
 import com.mmm.his.cer.utility.farser.ast.node.supplier.SetTheoryNodeSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.LookupContext;
 import com.mmm.his.cer.utility.farser.ast.parser.AstDescentParser;
@@ -25,7 +26,7 @@ import org.junit.Test;
 public class SetAstTest {
 
   TestContext context = new TestContext();
-  SetTheoryNodeSupplier nodeSupplier = new SetTheoryNodeSupplier();
+  SetTheoryNodeSupplier<String> nodeSupplier = new SetTheoryNodeSupplier<>();
   SetFormulaTokenFactory factory = new SetFormulaTokenFactory();
 
   @Test
@@ -91,7 +92,7 @@ public class SetAstTest {
         new AstDescentParser<>(tokens.iterator(), nodeSupplier);
 
     AbstractSyntaxTree<LookupContext<String>, List<String>> ast = parser.buildTree();
-
+    System.out.println(AbstractSyntaxTreePrinter.printTree(ast));
     return ast.evaluateExpression(context);
   }
 


### PR DESCRIPTION
To open up to more use cases, add a generic type definition to the SetTheoryNodeSupplier. This way any type can be used to returned by the LookupContext.

Adjust tests to account for new generic type.