### PR TITLE
Open up to allow different left and right return types

### DIFF
--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BaseNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BaseNonTerminal.java
@@ -8,14 +8,15 @@ import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
  * boolean evaluation result type.
  *
  * @param <C> The node context type used in the terminal nodes.
- * @param <E> The result type of each left/right expression
+ * @param <L> The result type of the left expression.
+ * @param <R> The result type of the right expression.
  *
  * @author Thomas Naeff
  */
-public abstract class BaseNonTerminal<C, E> implements NonTerminal<C, E> {
+public abstract class BaseNonTerminal<C, L, R> implements NonTerminal<C, L, R> {
 
-  protected Expression<C, E> left;
-  protected Expression<C, E> right;
+  protected Expression<C, L> left;
+  protected Expression<C, R> right;
 
   /**
    * Sets the left-side child node.
@@ -23,7 +24,7 @@ public abstract class BaseNonTerminal<C, E> implements NonTerminal<C, E> {
    * @param left The node to set
    */
   @Override
-  public void setLeft(Expression<C, E> left) {
+  public void setLeft(Expression<C, L> left) {
     this.left = left;
   }
 
@@ -33,7 +34,7 @@ public abstract class BaseNonTerminal<C, E> implements NonTerminal<C, E> {
    * @param right The node to set
    */
   @Override
-  public void setRight(Expression<C, E> right) {
+  public void setRight(Expression<C, R> right) {
     this.right = right;
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BaseNonTerminalExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BaseNonTerminalExpression.java
@@ -1,0 +1,35 @@
+package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
+
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
+
+/**
+ * Wraps together the BaseNonTerminal and Expression classes for easier implementation.
+ *
+ * @param <C> The node context type used in the terminal nodes.
+ * @param <L> The result type of the left expression.
+ * @param <R> The result type of the right expression.
+ * @param <E> The return type of this expression. 
+ *
+ * @author Rowan Simmons
+ */
+public abstract class BaseNonTerminalExpression<C, L, R, E> extends BaseNonTerminal<C, L, R>
+    implements Expression<C, E> {
+
+  @Override
+  public LtrExpressionIterator<C> iterator() {
+    return new LtrExpressionIterator<>(left, right);
+  }
+
+  @Override
+  public String print() {
+    // A default printing behavior. Can be overridden by implementations if needed.
+    return getClass().getSimpleName().toUpperCase();
+  }
+
+  @Override
+  public String toString() {
+    return "BaseNonTerminalExpression{" + "left=" + left + ", right=" + right + '}';
+  }
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BooleanNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BooleanNonTerminal.java
@@ -1,7 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
 
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
-import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 
 /**
  * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
@@ -14,8 +13,7 @@ import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
  * @implNote This non-terminal node has a return type of Boolean, which is different from the
  *     return types of the child nodes.
  */
-public abstract class BooleanNonTerminal<C, E> extends BaseNonTerminal<C, E, E> implements
-    Expression<C, Boolean> {
+public abstract class BooleanNonTerminal<C, E> extends NonTerminalExpression<C, E, Boolean> {
 
   @Override
   public LtrExpressionIterator<C> iterator() {

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BooleanNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BooleanNonTerminal.java
@@ -13,7 +13,7 @@ import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
  * @implNote This non-terminal node has a return type of Boolean, which is different from the
  *     return types of the child nodes.
  */
-public abstract class BooleanNonTerminal<C, E> extends NonTerminalExpression<C, E, Boolean> {
+public abstract class BooleanNonTerminal<C, E> extends OtherReturnNonTerminal<C, E, Boolean> {
 
   @Override
   public LtrExpressionIterator<C> iterator() {

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BooleanNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/BooleanNonTerminal.java
@@ -9,12 +9,12 @@ import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
  * result of a boolean type.
  *
  * @param <C> The node context type used in the terminal nodes.
- * @param <E> The return type of the left and right child nodes of this non-terminal node.
+ * @param <E> The return type of the left and right child nodes of this non-terminal node. 
  * @author Mike Funaro
- * @implNote This non-terminal node has a return type of Boolean, which is differnt from the
+ * @implNote This non-terminal node has a return type of Boolean, which is different from the
  *     return types of the child nodes.
  */
-public abstract class BooleanNonTerminal<C, E> extends BaseNonTerminal<C, E> implements
+public abstract class BooleanNonTerminal<C, E> extends BaseNonTerminal<C, E, E> implements
     Expression<C, Boolean> {
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/NonTerminal.java
@@ -11,19 +11,19 @@ import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
  *
  * @author Mike Funaro
  */
-public interface NonTerminal<C, E> {
+public interface NonTerminal<C, L, R> {
 
   /**
    * Set the left node.
    *
    * @param left the node to set.
    */
-  void setLeft(Expression<C, E> left);
+  void setLeft(Expression<C, L> left);
 
   /**
    * Set the right node.
    *
    * @param right the node to set.
    */
-  void setRight(Expression<C, E> right);
+  void setRight(Expression<C, R> right);
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/NonTerminalExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/NonTerminalExpression.java
@@ -1,30 +1,15 @@
 package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
 
-import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
-import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
-
 /**
- * Wraps together the BaseNonTerminal and Expression classes for easier implementation.
+ * Non-terminal expression class for classes that have the same right and left return types.
  *
  * @param <C> The node context type used in the terminal nodes.
- * @param <E> The result type of each left/right expression.
- * @param <R> The return type of this expression. 
+ * @param <L> The result type of the left and right expression.
+ * @param <E> The return type of this expression. 
  * 
  * @author Rowan Simmons
  */
-public abstract class NonTerminalExpression<C, E, R> extends BaseNonTerminal<C, E> 
-    implements Expression<C, R> {
-
-  @Override
-  public LtrExpressionIterator<C> iterator() {
-    return new LtrExpressionIterator<>(left, right);
-  }
-
-  @Override
-  public String print() {
-    // A default printing behavior. Can be overridden by implementations if needed.
-    return getClass().getSimpleName().toUpperCase();
-  }
+public abstract class NonTerminalExpression<C, L, E> extends BaseNonTerminalExpression<C, L, L, E> {
 
   @Override
   public String toString() {

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/OtherReturnNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/OtherReturnNonTerminal.java
@@ -9,11 +9,12 @@ package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
  * 
  * @author Rowan Simmons
  */
-public abstract class NonTerminalExpression<C, L, E> extends BaseNonTerminalExpression<C, L, L, E> {
+public abstract class OtherReturnNonTerminal<C, L, E> 
+    extends BaseNonTerminalExpression<C, L, L, E> {
 
   @Override
   public String toString() {
-    return "NonTerminalExpression{" + "left=" + left + ", right=" + right + '}';
+    return "OtherReturnNonTerminal{" + "left=" + left + ", right=" + right + '}';
   }
 
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/OtherRightNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/OtherRightNonTerminal.java
@@ -1,0 +1,13 @@
+package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
+
+/**
+ * For non-terminal expressions that have the same left and this return type, but a different 
+ * right return type.
+ *
+ * @param <C> The node context type used in the terminal nodes.
+ * @param <R> The result type of the right expression.
+ * @param <E> The result type of the left expression and this expression.
+ */
+public abstract class OtherRightNonTerminal<C, R, E> extends BaseNonTerminalExpression<C, E, R, E> {
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/SameTypeNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/SameTypeNonTerminal.java
@@ -1,0 +1,11 @@
+package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
+
+/**
+ * For non-terminal expressions that have the same left, right, and this return types.
+ *
+ * @param <C> The node context type used in the terminal nodes.
+ * @param <E> The result type of the left, right, and this expression.
+ */
+public abstract class SameTypeNonTerminal<C, E> extends BaseNonTerminalExpression<C, E, E, E> {
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/SetTheoryNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/SetTheoryNonTerminal.java
@@ -1,15 +1,13 @@
 package com.mmm.his.cer.utility.farser.ast.node.nonterminal;
 
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
-import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 
 /**
  * A non-terminal base class for Set theory.
  *
  * @author Mike Funaro
  */
-public abstract class SetTheoryNonTerminal<C, E> extends BaseNonTerminal<C, E> implements
-    Expression<C, E> {
+public abstract class SetTheoryNonTerminal<C, E> extends NonTerminalExpression<C, E, E> {
 
   @Override
   public LtrExpressionIterator<C> iterator() {

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/SetTheoryNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/nonterminal/SetTheoryNonTerminal.java
@@ -7,7 +7,7 @@ import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
  *
  * @author Mike Funaro
  */
-public abstract class SetTheoryNonTerminal<C, E> extends NonTerminalExpression<C, E, E> {
+public abstract class SetTheoryNonTerminal<C, E> extends SameTypeNonTerminal<C, E> {
 
   @Override
   public LtrExpressionIterator<C> iterator() {

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/supplier/NodeSupplier.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/supplier/NodeSupplier.java
@@ -35,7 +35,7 @@ public interface NodeSupplier<L extends LexerToken<?>, C> {
    * @param token The formula token/operand for which to create the node for
    * @return Non-terminal expression that was instantiated in this method.
    */
-  default NonTerminal<C, ?> createNonTerminalNode(L token) {
+  default NonTerminal<C, ?, ?> createNonTerminalNode(L token) {
     /*
      * Default implementation to satisfy existing token type (DRG and Domain) implementations which
      * relied on having only AND and OR nodes and this non-terminal-node creation implemented.

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/supplier/SetTheoryNodeSupplier.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/supplier/SetTheoryNodeSupplier.java
@@ -26,7 +26,7 @@ public class SetTheoryNodeSupplier<T> implements NodeSupplier<SetTheoryToken, Lo
   }
 
   @Override
-  public NonTerminal<LookupContext<T>, ?> createNonTerminalNode(SetTheoryToken token) {
+  public NonTerminal<LookupContext<T>, ?, ?> createNonTerminalNode(SetTheoryToken token) {
     switch (token.type) {
       case DIFFERENCE:
         return new DifferenceOperator<>();

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/AstDescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/AstDescentParser.java
@@ -146,23 +146,24 @@ public class AstDescentParser<L extends LexerToken<T>, T extends TokenType<?>, C
    *                               evaluation return type matches the other. It has to rely on
    *                               runtime (class cast) exceptions when malformed formulas or
    *                               implementations are used.
+   * @param <Y>                    The return type of the right expression.           
    * @param left                   The node to be used (or passed further down) as left-side node
    * @param leftOperatorPrecedence The operator precedence of the provided <code>left</code> node
    * @return Potentially a new (non-terminal/operator) node with a potential new evaluation return
    *     type. Or the input <code>left</code> node passed through with a matching evaluation
    *     return type.
    */
-  private <X> Expression<C, X> expression(Expression<C, X> left, int leftOperatorPrecedence) {
+  private <X, Y> Expression<C, X> expression(Expression<C, X> left, int leftOperatorPrecedence) {
     left = term(left, leftOperatorPrecedence);
     // Higher value means lower precedence
     while (getCurrentTokenAstType().isLowerOrSamePrecedence(leftOperatorPrecedence)) {
-      NonTerminal<C, X> operator = uncheckedCast(
+      NonTerminal<C, X, Y> operator = uncheckedCast(
           nodeSupplier.createNonTerminalNode(currentToken));
       // Save the current operator precedence before advancing the token iterator
       int operatorPrecedence = getCurrentOperatorPrecedence();
       this.eat();
       operator.setLeft(left);
-      Expression<C, X> right = term(left, operatorPrecedence);
+      Expression<C, Y> right = uncheckedCast(term(left, operatorPrecedence));
       operator.setRight(right);
       // The non-terminal/operator node, as combination of left/right evaluation, may have a
       // different evaluation return type than the individual left/right nodes.
@@ -181,22 +182,23 @@ public class AstDescentParser<L extends LexerToken<T>, T extends TokenType<?>, C
    *                               evaluation return type matches the other. It has to rely on
    *                               runtime (class cast) exceptions when malformed formulas or
    *                               implementations are used.
+   * @param <Y>                    The return type of the right expression.              
    * @param left                   The node to be used (or passed further down) as left-side node
    * @param leftOperatorPrecedence The operator precedence of the provided <code>left</code> node
    * @return Potentially a new (non-terminal/operator) node with a potential new evaluation return
    *     type. Or the input <code>left</code> node passed through with a matching evaluation
    *     return type.
    */
-  private <X> Expression<C, X> term(Expression<C, X> left, int leftOperatorPrecedence) {
+  private <X, Y> Expression<C, X> term(Expression<C, X> left, int leftOperatorPrecedence) {
     left = factor(left, leftOperatorPrecedence);
     while (getCurrentTokenAstType().isHigherPrecedence(leftOperatorPrecedence)) {
-      NonTerminal<C, X> operator = uncheckedCast(
+      NonTerminal<C, X, Y> operator = uncheckedCast(
           nodeSupplier.createNonTerminalNode(currentToken));
       // Save the current operator precedence before advancing the token iterator
       int operatorPrecedence = getCurrentOperatorPrecedence();
       this.eat();
       operator.setLeft(left);
-      Expression<C, X> right = term(left, operatorPrecedence);
+      Expression<C, Y> right = uncheckedCast(term(left, operatorPrecedence));
       operator.setRight(right);
       // The non-terminal/operator node, as combination of left/right evaluation, may have a
       // different evaluation return type than the individual left/right nodes.
@@ -208,19 +210,20 @@ public class AstDescentParser<L extends LexerToken<T>, T extends TokenType<?>, C
   /**
    * Method which will build the negation/not node, with only one child node.
    *
-   * @param <R>                    The (boolean) return type of the negated <code>left</code> node,
+   * @param <X>                    The (boolean) return type of the negated <code>left</code> node,
    *                               as well as the (boolean) return type of the returned not-node.
    *                               This data type is not set as {@link Boolean} to avoid for
    *                               (unchecked) casting. In general, it can not programmatically
    *                               guarantee that one nodes evaluation return type matches the
    *                               other. It has to rely on runtime (class cast) exceptions when
    *                               malformed formulas or implementations are used.
+   * @param <Y>                    The return type of the right expression.              
    * @param left                   The node to be used (or passed further down) as left-side node
    * @param leftOperatorPrecedence The operator precedence of the provided <code>left</code> node
    * @return A new (non-terminal/operator) node with a new evaluation return type
    */
-  private <R> Expression<C, R> not(Expression<C, R> left, int leftOperatorPrecedence) {
-    NonTerminal<C, R> operator = uncheckedCast(
+  private <X, Y> Expression<C, X> not(Expression<C, X> left, int leftOperatorPrecedence) {
+    NonTerminal<C, X, Y> operator = uncheckedCast(
         nodeSupplier.createNonTerminalNode(currentToken));
     this.eat(AstCommonTokenType.NOT); // Move iterator if 'NOT'
     left = factor(left, leftOperatorPrecedence);

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/ComplexFormulaAstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/ComplexFormulaAstTest.java
@@ -395,5 +395,35 @@ public class ComplexFormulaAstTest {
 
     assertThat(result.getResult(), is(false));
   }
+  
+  @Test
+  public void evaluateHasTrue() throws Exception {
+    String input = "a1bc HAS 1";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext, Boolean> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext, Boolean> ast = parser.buildTree();
+
+    ExpressionResult<ComplexTestAstContext, Boolean> result =
+        ast.evaluateExpression(new ComplexTestAstContext());
+
+    assertThat(result.getResult(), is(true));
+  }
+
+  @Test
+  public void evaluateHasFalse() throws Exception {
+    String input = "a2bc HAS 1";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext, Boolean> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext, Boolean> ast = parser.buildTree();
+
+    ExpressionResult<ComplexTestAstContext, Boolean> result =
+        ast.evaluateExpression(new ComplexTestAstContext());
+
+    assertThat(result.getResult(), is(false));
+  }
 
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ComplexTestTokenType.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ComplexTestTokenType.java
@@ -32,7 +32,7 @@ public enum ComplexTestTokenType implements AstTokenType<ComplexTestTokenType> {
   EQUAL("=", 2),
   AND("&", 3),
   OR("|", 4),
-
+  HAS("HAS", 1),
   IN("IN", 1),
   IN_TABLE("IN TABLE", 1);
 

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestAstNodeSupplier.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestAstNodeSupplier.java
@@ -6,6 +6,7 @@ import com.mmm.his.cer.utility.farser.ast.node.operator.bool.Not;
 import com.mmm.his.cer.utility.farser.ast.node.operator.bool.Or;
 import com.mmm.his.cer.utility.farser.ast.node.supplier.NodeSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal.ComplexTestHasOperator;
 import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal.ComplexTestEqualOperator;
 import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal.ComplexTestGreaterThanOperator;
 import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal.ComplexTestInOperator;
@@ -58,7 +59,7 @@ public class ComplexTestAstNodeSupplier implements NodeSupplier<ComplexTestToken
 
 
   @Override
-  public BaseNonTerminal<ComplexTestAstContext, ?> createNonTerminalNode(ComplexTestToken token) {
+  public BaseNonTerminal<ComplexTestAstContext, ?, ?> createNonTerminalNode(ComplexTestToken token) {
 
     switch (token.type) {
       case GT:
@@ -73,6 +74,8 @@ public class ComplexTestAstNodeSupplier implements NodeSupplier<ComplexTestToken
         return new Or<>();
       case NOT:
         return new Not<>();
+      case HAS:
+        return new ComplexTestHasOperator<>();
       case IN:
         return new ComplexTestInOperator<>();
       case IN_TABLE:

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestEqualOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestEqualOperator.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal;
 
-import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression;
+import com.mmm.his.cer.utility.farser.ast.node.nonterminal.OtherReturnNonTerminal;
 
 /**
  *
@@ -9,7 +9,7 @@ import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression
  *
  * @param <C>
  */
-public class ComplexTestEqualOperator<C> extends NonTerminalExpression<C, Integer, Boolean> {
+public class ComplexTestEqualOperator<C> extends OtherReturnNonTerminal<C, Integer, Boolean> {
 
   @Override
   public Boolean evaluate(C context) {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestGreaterThanOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestGreaterThanOperator.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal;
 
-import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression;
+import com.mmm.his.cer.utility.farser.ast.node.nonterminal.OtherReturnNonTerminal;
 
 /**
  *
@@ -9,7 +9,7 @@ import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression
  *
  * @param <C>
  */
-public class ComplexTestGreaterThanOperator<C> extends NonTerminalExpression<C, Integer, Boolean> {
+public class ComplexTestGreaterThanOperator<C> extends OtherReturnNonTerminal<C, Integer, Boolean> {
 
   @Override
   public Boolean evaluate(C context) {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestHasOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestHasOperator.java
@@ -1,0 +1,29 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal;
+
+import com.mmm.his.cer.utility.farser.ast.node.nonterminal.BaseNonTerminalExpression;
+
+/**
+ * Operator that has a left and right with different return types.
+ */
+public class ComplexTestHasOperator<C> extends BaseNonTerminalExpression<C, String, Integer, Boolean> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    String leftResult = left.evaluate(context);
+    
+    Integer rightResult = right.evaluate(context);
+    String rightStr = String.valueOf(rightResult);
+    
+    return leftResult.contains(rightStr);
+  }
+
+  @Override
+  public String print() {
+    return "HAS";
+  }
+
+  @Override
+  public String toString() {
+    return "Has{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestInOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestInOperator.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal;
 
-import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression;
+import com.mmm.his.cer.utility.farser.ast.node.nonterminal.OtherReturnNonTerminal;
 
 /**
  *
@@ -9,7 +9,7 @@ import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression
  *
  * @param <C>
  */
-public class ComplexTestInOperator<C> extends NonTerminalExpression<C, String, Boolean> {
+public class ComplexTestInOperator<C> extends OtherReturnNonTerminal<C, String, Boolean> {
 
   @Override
   public Boolean evaluate(C context) {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestInTableOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestInTableOperator.java
@@ -1,7 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal;
 
-import com.mmm.his.cer.utility.farser.ast.node.nonterminal.BooleanNonTerminal;
-import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression;
+import com.mmm.his.cer.utility.farser.ast.node.nonterminal.OtherReturnNonTerminal;
 
 /**
  *
@@ -10,7 +9,7 @@ import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression
  *
  * @param <C>
  */
-public class ComplexTestInTableOperator<C> extends NonTerminalExpression<C, String, Boolean> {
+public class ComplexTestInTableOperator<C> extends OtherReturnNonTerminal<C, String, Boolean> {
 
   @Override
   public Boolean evaluate(C context) {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestLessThanOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/non_terminal/ComplexTestLessThanOperator.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast_complex.setup.ast.non_terminal;
 
-import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression;
+import com.mmm.his.cer.utility.farser.ast.node.nonterminal.OtherReturnNonTerminal;
 
 /**
  *
@@ -9,7 +9,7 @@ import com.mmm.his.cer.utility.farser.ast.node.nonterminal.NonTerminalExpression
  *
  * @param <C>
  */
-public class ComplexTestLessThanOperator<C> extends NonTerminalExpression<C, Integer, Boolean> {
+public class ComplexTestLessThanOperator<C> extends OtherReturnNonTerminal<C, Integer, Boolean> {
 
   @Override
   public Boolean evaluate(C context) {


### PR DESCRIPTION
Previously, the left and right evaluation results had to be the same type. This allows the types to be different.

This includes a breaking change, so if we decide to keep it we will probably have to bump up to 6.0.0.